### PR TITLE
Fix typo in code and little simplification - fixes #1

### DIFF
--- a/Programmer.cpp
+++ b/Programmer.cpp
@@ -149,7 +149,7 @@ void IProgrammerStrategy::erase_write(uint32_t address, const std::span<const st
 /* ETarget */
 
 ETarget::ETarget(const Protocol::Status status)
-	: Exception(), _status(status)
+	: Exception(), status(status)
 {
 	switch (status) {
 		case Protocol::STATUS_INV_OP:

--- a/Programmer.hpp
+++ b/Programmer.hpp
@@ -21,7 +21,7 @@
 class ETarget : public Exception {
 	public:
 		ETarget(const Protocol::Status status);
-		const Protocol::Status _status;
+		const Protocol::Status status;
 };
 
 struct ProgrammerDescriptor {


### PR DESCRIPTION
Project Programmer failed to build due to typo in the ETarget member name.
Fixed the typo.

Signed-off-by: Andrey Borisovich <business@borisovich.com>